### PR TITLE
Swap Controllers for Compact Remotes

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -97773,12 +97773,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
 /obj/item/controller,
-/obj/item/controller,
-/obj/item/controller,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/item/compact_remote,
+/obj/item/compact_remote,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "uft" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -32950,8 +32950,8 @@
 /obj/machinery/airalarm/directional/north,
 /obj/structure/rack,
 /obj/item/controller,
-/obj/item/controller,
-/obj/item/controller,
+/obj/item/compact_remote,
+/obj/item/compact_remote,
 /turf/open/floor/iron/white/corner,
 /area/science/misc_lab)
 "kbG" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -87391,9 +87391,9 @@
 	dir = 8
 	},
 /obj/item/controller,
-/obj/item/controller,
-/obj/item/controller,
 /obj/machinery/light/directional/west,
+/obj/item/compact_remote,
+/obj/item/compact_remote,
 /turf/open/floor/iron/showroomfloor,
 /area/science/test_area)
 "xfz" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -36172,8 +36172,8 @@
 /obj/structure/table,
 /obj/structure/cable,
 /obj/item/controller,
-/obj/item/controller,
-/obj/item/controller,
+/obj/item/compact_remote,
+/obj/item/compact_remote,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "jPt" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -43267,8 +43267,8 @@
 /obj/structure/rack,
 /obj/machinery/light/directional/south,
 /obj/item/controller,
-/obj/item/controller,
-/obj/item/controller,
+/obj/item/compact_remote,
+/obj/item/compact_remote,
 /turf/open/floor/iron,
 /area/space)
 "mzF" = (


### PR DESCRIPTION
Swaps 2 of the controller shells for compact remotes on each map.

I misread which one was the basic shell.