### PR TITLE
Tweaks Starfury piloting

### DIFF
--- a/code/modules/shuttle/battlecruiser_starfury.dm
+++ b/code/modules/shuttle/battlecruiser_starfury.dm
@@ -117,6 +117,9 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	shuttleId = "SBC_starfury"
 	shuttlePortId = "SBC_starfury_custom"
+	can_rotate = FALSE
+	world_y_max = 5
+	world_x_max = 5
 
 // Once the Starfury reaches the staiton z-level, it cannot have its custom port moved.
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/starfury/attack_hand(mob/user, list/modifiers)

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -26,6 +26,13 @@
 	var/turf/designating_target_loc
 	var/jammed = FALSE
 
+	/// Whether we can rotate this ship or not.
+	var/can_rotate = TRUE
+	/// How much buffer space we require between the world edge vertically
+	var/world_y_max = 10
+	/// How much buffer space we require between the world edge horizontally
+	var/world_x_max = 10
+
 /obj/machinery/computer/camera_advanced/shuttle_docker/Initialize(mapload)
 	. = ..()
 	GLOB.navigation_computers += src
@@ -71,7 +78,7 @@
 		jump_action = new /datum/action/innate/camera_jump/shuttle_docker
 	..()
 
-	if(rotate_action)
+	if(can_rotate && rotate_action)
 		rotate_action.target = user
 		rotate_action.Grant(user)
 		actions += rotate_action
@@ -249,7 +256,7 @@
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/proc/checkLandingTurf(turf/T, list/overlappers)
 	// Too close to the map edge is never allowed
-	if(!T || T.x <= 10 || T.y <= 10 || T.x >= world.maxx - 10 || T.y >= world.maxy - 10)
+	if(!T || T.x <= world_x_max || T.y <= world_y_max || T.x >= world.maxx - world_x_max || T.y >= world.maxy - world_y_max)
 		return SHUTTLE_DOCKER_BLOCKED
 	// If it's one of our shuttle areas assume it's ok to be there
 	if(shuttle_port.shuttle_areas[T.loc])


### PR DESCRIPTION
- Allows the Starfury to park closer to world boundary by dehardcoding some nav shuttle vars
- Disallows the Starfury from rotating, just to prevent some things from breaking / works slightly better (IMO)